### PR TITLE
The ability to add html markup into LinkToIndividualPageFormat

### DIFF
--- a/src/PagedList.Mvc/HtmlHelper.cs
+++ b/src/PagedList.Mvc/HtmlHelper.cs
@@ -68,7 +68,6 @@ namespace PagedList.Mvc
             {
                 InnerHtml = format(targetPageNumber)
             };
-			//page.SetInnerText(format(targetPageNumber));
 
 			if (i == list.PageNumber)
 				return WrapInListItem(page, options, "active");


### PR DESCRIPTION
Hi, I need to format page number with some html markup, but I see you use SetInnerText in HtmlHelper.Page method. Is it possible to add formatted number using InnerHtml (like in HtmlHelper.Next method). I've made fork and fixed this issue, but I'm not sure that this way is completely elegant.
