### PR TITLE
PagedList.css reference in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,6 +128,14 @@ The HTML output by Html.PagedListPager is configured to be styled automatically 
 
 ![Out-of-the-box Pager Configurations](https://github.com/TroyGoode/PagedList/raw/master/misc/DefaultPagingControlStyles.png)
 
+If your project does not reference the [Twitter Bootstrap](http://twitter.github.com/bootstrap) project, the NuGet package contains a stand-alone `PagedList.css`. You can reference this style sheet manually or, if using MVC4, reference within `BundleConfig.cs` and take advantage of bundling and minification automatically. 
+
+Simply append `"~/Content/PagedList.css"` to where Site.css is already bundled, yielding:
+
+```csharp
+bundles.Add(new StyleBundle("~/Content/css").Include("~/Content/site.css", "~/Content/PagedList.css"));
+```
+
 ### Out-of-the-box Pager Configurations
 
 ```html


### PR DESCRIPTION
I don't use the full Twitter Bootstrap package. Instead, I wanted to
reference the PagedList.css file that comes in the NuGet package. I
noticed this file was omitted from the README and wanted to outline how
a user can leverage MVC4's new bundling and minification feature to
include it if they don't already use the full Bootstrap styling.
