### PR TITLE
I have added an extra option to allow for AjaxOptions to be used

### DIFF
--- a/src/PagedList.Mvc/PagedListRenderOptions.cs
+++ b/src/PagedList.Mvc/PagedListRenderOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Mvc;
+using System.Web.Mvc.Ajax;
 
 namespace PagedList.Mvc
 {
@@ -208,9 +209,9 @@ namespace PagedList.Mvc
 		/// Enables ASP.NET MVC's unobtrusive AJAX feature. An XHR request will retrieve HTML from the clicked page and replace the innerHtml of the provided element ID.
 		/// </summary>
 		/// <param name="options">The preferred Html.PagedList(...) style options.</param>
-		/// <param name="id">The element ID ("#my_id") of the element whose innerHtml should be replaced.</param>
+        /// <param name="ajaxOptions">The ajax options that will put into the link</param>
 		/// <returns>The PagedListRenderOptions value passed in, with unobtrusive AJAX attributes added to the page links.</returns>
-		public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(PagedListRenderOptions options, string id)
+		public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(PagedListRenderOptions options, AjaxOptions ajaxOptions)
 		{
 			options.FunctionToTransformEachPageLink = (liTagBuilder, aTagBuilder) =>
 			                                          	{
@@ -220,15 +221,12 @@ namespace PagedList.Mvc
 																var liClasses = liTagBuilder.Attributes["class"].Split(' ');
 																appendUnobtrusiveAjaxAttributes = !liClasses.Contains("disabled") && !liClasses.Contains("active");
 															}
-
-															if (appendUnobtrusiveAjaxAttributes)
-															{
-																aTagBuilder.Attributes.Add("data-ajax", "true");
-																aTagBuilder.Attributes.Add("data-ajax-method", "get");
-																aTagBuilder.Attributes.Add("data-ajax-mode", "replace");
-																aTagBuilder.Attributes.Add("data-ajax-update", id);																
-															}
-
+                                                            if (ajaxOptions != null)
+                                                            {
+                                                                foreach (var ajaxOption in ajaxOptions.ToUnobtrusiveHtmlAttributes())
+                                                                    aTagBuilder.Attributes.Add(ajaxOption.Key, ajaxOption.Value.ToString());
+                                                            }
+                                                           
 															liTagBuilder.InnerHtml = aTagBuilder.ToString();
 			                                          		return liTagBuilder;
 			                                          	};
@@ -238,12 +236,31 @@ namespace PagedList.Mvc
 		/// <summary>
 		/// Enables ASP.NET MVC's unobtrusive AJAX feature. An XHR request will retrieve HTML from the clicked page and replace the innerHtml of the provided element ID.
 		/// </summary>
-		/// <param name="id">The element ID ("#my_id") of the element whose innerHtml should be replaced.</param>
+		/// <param name="id">The element ID ("my_id") of the element whose innerHtml should be replaced, if # is included at the start this will be removed.</param>
 		/// <returns>A default instance of PagedListRenderOptions value passed in, with unobtrusive AJAX attributes added to the page links.</returns>
 		public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(string id)
 		{
-			return EnableUnobtrusiveAjaxReplacing(new PagedListRenderOptions(), id);
+            if (id.StartsWith("#"))
+                id = id.Substring(1);
+
+            AjaxOptions ajaxOptions = new AjaxOptions()
+            {
+                 HttpMethod = "GET",
+                 InsertionMode = InsertionMode.Replace,
+                 UpdateTargetId = id
+            };
+            
+            return EnableUnobtrusiveAjaxReplacing(new PagedListRenderOptions(), ajaxOptions);
 		}
+        /// <summary>
+        /// Enables ASP.NET MVC's unobtrusive AJAX feature. An XHR request will retrieve HTML from the clicked page and replace the innerHtml of the provided element ID.
+        /// </summary>
+        /// <param name="ajaxOptions">Ajax options that will be used to generate the unobstrusive tags on the link</param>
+        /// <returns>A default instance of PagedListRenderOptions value passed in, with unobtrusive AJAX attributes added to the page links.</returns>
+        public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(AjaxOptions ajaxOptions)
+        {
+            return EnableUnobtrusiveAjaxReplacing(new PagedListRenderOptions(), ajaxOptions);
+        }
 
 		///<summary>
         /// Also includes links to First and Last pages.

--- a/src/PagedList.Mvc4.Example/Views/UnobtrusiveAjax/UnobtrusiveAjax_Partial.cshtml
+++ b/src/PagedList.Mvc4.Example/Views/UnobtrusiveAjax/UnobtrusiveAjax_Partial.cshtml
@@ -10,3 +10,5 @@
 </ul>
 
 @Html.PagedListPager((IPagedList)ViewBag.Names, page => Url.Action("Index", new { page }), PagedListRenderOptions.EnableUnobtrusiveAjaxReplacing("#unobtrusive"))
+
+@Html.PagedListPager((IPagedList)ViewBag.Names, page => Url.Action("Index", new { page }), PagedListRenderOptions.EnableUnobtrusiveAjaxReplacing( new AjaxOptions(){  HttpMethod = "POST", UpdateTargetId = "unobtrusive" }))


### PR DESCRIPTION
Change the EnableUnobtrusiveAjaxReplacing to accept AjaxOption with the
Id being bundled into AjaxOption if it is passed.

Wanted to use your paging but much current code needed to know when the ajax had been completed. To do this I need to specify the OnComplete JavaScript function to call. Having a look at your coded I though this was the quick and easiest way of getting this functionality in but still allowing legacy versions to work.

Let me know what you think.
