### PR TITLE
Add link metadata to transform page link delegate

### DIFF
--- a/src/PagedList.Mvc/HtmlHelper.cs
+++ b/src/PagedList.Mvc/HtmlHelper.cs
@@ -18,13 +18,13 @@ namespace PagedList.Mvc
 			return li;
 		}
 
-		private static TagBuilder WrapInListItem(TagBuilder inner, PagedListRenderOptions options, params string[] classes)
+		private static TagBuilder WrapInListItem(int? targetPageNumber, IPagedList list, TagBuilder inner, PagedListRenderOptions options, params string[] classes)
 		{
 			var li = new TagBuilder("li");
 			foreach (var @class in classes)
 				li.AddCssClass(@class);
 			if (options.FunctionToTransformEachPageLink != null)
-				return options.FunctionToTransformEachPageLink(li, inner);
+				return options.FunctionToTransformEachPageLink(targetPageNumber, list, li, inner);
 			li.InnerHtml = inner.ToString();
 			return li;
 		}
@@ -38,10 +38,10 @@ namespace PagedList.Mvc
 			            	};
 			
 			if (list.IsFirstPage)
-				return WrapInListItem(first, options, "PagedList-skipToFirst", "disabled");
+				return WrapInListItem(null, list, first, options, "PagedList-skipToFirst", "disabled");
 
 			first.Attributes["href"] = generatePageUrl(targetPageNumber);
-			return WrapInListItem(first, options, "PagedList-skipToFirst");
+			return WrapInListItem(targetPageNumber, list, first, options, "PagedList-skipToFirst");
 		}
 
 		private static TagBuilder Previous(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
@@ -53,10 +53,10 @@ namespace PagedList.Mvc
 			               	};
 			
 			if (!list.HasPreviousPage)
-				return WrapInListItem(previous, options, "PagedList-skipToPrevious", "disabled");
+				return WrapInListItem(null, list, previous, options, "PagedList-skipToPrevious", "disabled");
 
 			previous.Attributes["href"] = generatePageUrl(targetPageNumber);
-			return WrapInListItem(previous, options, "PagedList-skipToPrevious");
+			return WrapInListItem(targetPageNumber, list, previous, options, "PagedList-skipToPrevious");
 		}
 
 		private static TagBuilder Page(int i, IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
@@ -68,10 +68,10 @@ namespace PagedList.Mvc
 			page.SetInnerText(format(targetPageNumber));
 
 			if (i == list.PageNumber)
-				return WrapInListItem(page, options, "active");
+				return WrapInListItem(targetPageNumber, list, page, options, "active");
 
 			page.Attributes["href"] = generatePageUrl(targetPageNumber);
-			return WrapInListItem(page, options);
+			return WrapInListItem(targetPageNumber, list, page, options);
 		}
 
 		private static TagBuilder Next(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
@@ -83,10 +83,10 @@ namespace PagedList.Mvc
 			           	};
 			
 			if (!list.HasNextPage)
-				return WrapInListItem(next, options, "PagedList-skipToNext", "disabled");
+				return WrapInListItem(null, list, next, options, "PagedList-skipToNext", "disabled");
 
 			next.Attributes["href"] = generatePageUrl(targetPageNumber);
-			return WrapInListItem(next, options, "PagedList-skipToNext");
+			return WrapInListItem(targetPageNumber, list, next, options, "PagedList-skipToNext");
 		}
 
 		private static TagBuilder Last(IPagedList list, Func<int, string> generatePageUrl, PagedListRenderOptions options)
@@ -98,10 +98,10 @@ namespace PagedList.Mvc
 			           	};
 			
 			if (list.IsLastPage)
-				return WrapInListItem(last, options, "PagedList-skipToLast", "disabled");
+				return WrapInListItem(null, list, last, options, "PagedList-skipToLast", "disabled");
 
 			last.Attributes["href"] = generatePageUrl(targetPageNumber);
-			return WrapInListItem(last, options, "PagedList-skipToLast");
+			return WrapInListItem(targetPageNumber, list, last, options, "PagedList-skipToLast");
 		}
 
 		private static TagBuilder PageCountAndLocationText(IPagedList list, PagedListRenderOptions options)
@@ -109,7 +109,7 @@ namespace PagedList.Mvc
 			var text = new TagBuilder("a");
 			text.SetInnerText(string.Format(options.PageCountAndCurrentLocationFormat, list.PageNumber, list.PageCount));
 
-			return WrapInListItem(text, options, "PagedList-pageCountAndLocation", "disabled");
+			return WrapInListItem(null, list, text, options, "PagedList-pageCountAndLocation", "disabled");
 		}
 
 		private static TagBuilder ItemSliceAndTotalText(IPagedList list, PagedListRenderOptions options)
@@ -117,17 +117,17 @@ namespace PagedList.Mvc
 			var text = new TagBuilder("a");
 			text.SetInnerText(string.Format(options.ItemSliceAndTotalFormat, list.FirstItemOnPage, list.LastItemOnPage, list.TotalItemCount));
 
-			return WrapInListItem(text, options, "PagedList-pageCountAndLocation", "disabled");
+			return WrapInListItem(null, list, text, options, "PagedList-pageCountAndLocation", "disabled");
 		}
 
-		private static TagBuilder Ellipses(PagedListRenderOptions options)
+		private static TagBuilder Ellipses(IPagedList list, PagedListRenderOptions options)
 		{
 			var a = new TagBuilder("a")
 			        	{
 			        		InnerHtml = options.EllipsesFormat
 			        	};
 
-			return WrapInListItem(a, options, "PagedList-ellipses", "disabled");
+			return WrapInListItem(null, list, a, options, "PagedList-ellipses", "disabled");
 		}
 
 		///<summary>
@@ -200,7 +200,7 @@ namespace PagedList.Mvc
 			{
 				//if there are previous page numbers not displayed, show an ellipsis
 				if (options.DisplayEllipsesWhenNotShowingAllPageNumbers && firstPageToDisplay > 1)
-					listItemLinks.Add(Ellipses(options));
+					listItemLinks.Add(Ellipses(list, options));
 
 				foreach (var i in Enumerable.Range(firstPageToDisplay, pageNumbersToDisplay))
 				{
@@ -214,7 +214,7 @@ namespace PagedList.Mvc
 
 				//if there are subsequent page numbers not displayed, show an ellipsis
 				if (options.DisplayEllipsesWhenNotShowingAllPageNumbers && (firstPageToDisplay + pageNumbersToDisplay - 1) < list.PageCount)
-					listItemLinks.Add(Ellipses(options));
+					listItemLinks.Add(Ellipses(list, options));
 			}
 
 			//next

--- a/src/PagedList.Mvc/PagedListRenderOptions.cs
+++ b/src/PagedList.Mvc/PagedListRenderOptions.cs
@@ -203,7 +203,7 @@ namespace PagedList.Mvc
 		/// <summary>
 		/// An extension point which allows you to fully customize the anchor tags used for clickable pages, as well as navigation features such as Next, Last, etc.
 		/// </summary>
-		public Func<TagBuilder, TagBuilder, TagBuilder> FunctionToTransformEachPageLink { get; set; }
+		public Func<int?, IPagedList, TagBuilder, TagBuilder, TagBuilder> FunctionToTransformEachPageLink { get; set; }
 
 		/// <summary>
 		/// Enables ASP.NET MVC's unobtrusive AJAX feature. An XHR request will retrieve HTML from the clicked page and replace the innerHtml of the provided element ID.
@@ -213,7 +213,7 @@ namespace PagedList.Mvc
 		/// <returns>The PagedListRenderOptions value passed in, with unobtrusive AJAX attributes added to the page links.</returns>
         public static PagedListRenderOptions EnableUnobtrusiveAjaxReplacing(PagedListRenderOptions options, AjaxOptions ajaxOptions)
 		{
-			options.FunctionToTransformEachPageLink = (liTagBuilder, aTagBuilder) =>
+			options.FunctionToTransformEachPageLink = (targetPageNumber, list, liTagBuilder, aTagBuilder) =>
 				                                          {
 																var liClass = liTagBuilder.Attributes.ContainsKey("class") ? liTagBuilder.Attributes["class"] ?? "" : "";
 																if (ajaxOptions != null && !liClass.Contains("disabled") && !liClass.Contains("active"))


### PR DESCRIPTION
Now the transform page link delegate has access to things such as the current page, total page number, the target page, etc.

This was useful for me because I wanted to add the target page number in a data attribute on all pagination links including next, first, etc. Could be helpful for Issue #54.

```
public static PagedListRenderOptions AddTargetPageDataAttribute
{
    get
    {
        return new PagedListRenderOptions
        {
            FunctionToTransformEachPageLink = (targetPageNumber, list, liTagBuilder, aTagBuilder) =>
            {
                if (targetPageNumber.HasValue)
                    aTagBuilder.Attributes.Add("data-target-page", targetPageNumber.ToString());

                liTagBuilder.InnerHtml = aTagBuilder.ToString();
                return liTagBuilder;
            }
        };
    }
}
```

Thanks so much for the time and effort you've spent on this repo, @TroyGoode. It's an awesome resource. Keep up the great work :)
