### PR TITLE
Append unobtrusive ajax url generator (attribute data-ajax-url)

### DIFF
--- a/src/PagedList.Mvc/PagedListRenderOptions.cs
+++ b/src/PagedList.Mvc/PagedListRenderOptions.cs
@@ -38,6 +38,7 @@ namespace PagedList.Mvc
 			ContainerDivClasses = new [] { "pagination-container" };
 			UlElementClasses = new[] { "pagination" };
 			LiElementClasses = Enumerable.Empty<string>();
+            UnobtrusiveAjaxAttrName = "data-ajax-url";
 		}
 
 		///<summary>
@@ -204,6 +205,11 @@ namespace PagedList.Mvc
 		/// An extension point which allows you to fully customize the anchor tags used for clickable pages, as well as navigation features such as Next, Last, etc.
 		/// </summary>
 		public Func<TagBuilder, TagBuilder, TagBuilder> FunctionToTransformEachPageLink { get; set; }
+
+        /// <summary>
+        /// Specifies an attribute name to append generated unobtrusive ajax url
+        /// </summary>
+        public string UnobtrusiveAjaxAttrName { get; set; }
 
 		/// <summary>
 		/// Enables ASP.NET MVC's unobtrusive AJAX feature. An XHR request will retrieve HTML from the clicked page and replace the innerHtml of the provided element ID.


### PR DESCRIPTION
Sometimes required to perform ajax queries to a different url address. It requires tag attribute "data-ajax-url".
I changed the helper methods for this feature (leaving backward compatibility):

Using helper method in view:
@Html.PagedListPager(
&nbsp;&nbsp;&nbsp;&nbsp;Model, 
&nbsp;&nbsp;&nbsp;&nbsp;page => Url.Action("Index", new { page, size = Model.PageSize }), 
&nbsp;&nbsp;&nbsp;&nbsp;page => Url.Action("Items", new { page, size = Model.PageSize }), // Unobtrusive ajax url generator
&nbsp;&nbsp;&nbsp;&nbsp;PagedListRenderOptions.EnableUnobtrusiveAjaxReplacing("containerId")
);

Result markup:
&lt;a href=&quot;/users/page-2&quot; data-ajax-url=&quot;/users/items?page=2&amp;size=25&quot; data-ajax-...&gt;2&lt;/a&gt;
