### PR TITLE
Functional Ellipses Option

### DIFF
--- a/src/PagedList.Mvc/HtmlHelper.cs
+++ b/src/PagedList.Mvc/HtmlHelper.cs
@@ -122,15 +122,18 @@ namespace PagedList.Mvc
 			return WrapInListItem(text, options, "PagedList-pageCountAndLocation", "disabled");
 		}
 
-		private static TagBuilder Ellipses(PagedListRenderOptions options)
-		{
-			var a = new TagBuilder("a")
-			        	{
-			        		InnerHtml = options.EllipsesFormat
-			        	};
+		private static TagBuilder Ellipses(PagedListRenderOptions options, Func<int, string> generatePageUrl, int targetPageNumber)
+        {
+            var a = new TagBuilder("a")
+                        {
+                            InnerHtml = options.EllipsesFormat
+                        };
 
-			return WrapInListItem(a, options, "PagedList-ellipses", "disabled");
-		}
+            if (options.EnableEllipsesNavigation)
+                a.Attributes["href"] = generatePageUrl(targetPageNumber);
+
+            return WrapInListItem(a, options, "PagedList-ellipses", options.EnableEllipsesNavigation ? null : "disabled");
+        }
 
 		///<summary>
 		///	Displays a configurable paging control for instances of PagedList.
@@ -202,7 +205,7 @@ namespace PagedList.Mvc
 			{
 				//if there are previous page numbers not displayed, show an ellipsis
 				if (options.DisplayEllipsesWhenNotShowingAllPageNumbers && firstPageToDisplay > 1)
-					listItemLinks.Add(Ellipses(options));
+                    listItemLinks.Add(Ellipses(options, generatePageUrl, firstPageToDisplay - 1));
 
 				foreach (var i in Enumerable.Range(firstPageToDisplay, pageNumbersToDisplay))
 				{
@@ -216,7 +219,7 @@ namespace PagedList.Mvc
 
 				//if there are subsequent page numbers not displayed, show an ellipsis
 				if (options.DisplayEllipsesWhenNotShowingAllPageNumbers && (firstPageToDisplay + pageNumbersToDisplay - 1) < list.PageCount)
-					listItemLinks.Add(Ellipses(options));
+                    listItemLinks.Add(Ellipses(options, generatePageUrl, (firstPageToDisplay + pageNumbersToDisplay)));
 			}
 
 			//next

--- a/src/PagedList.Mvc/PagedListRenderOptions.cs
+++ b/src/PagedList.Mvc/PagedListRenderOptions.cs
@@ -38,6 +38,7 @@ namespace PagedList.Mvc
 			ContainerDivClasses = new [] { "pagination-container" };
 			UlElementClasses = new[] { "pagination" };
 			LiElementClasses = Enumerable.Empty<string>();
+			EnableEllipsesNavigation = false;
 		}
 
 		///<summary>
@@ -204,6 +205,11 @@ namespace PagedList.Mvc
 		/// An extension point which allows you to fully customize the anchor tags used for clickable pages, as well as navigation features such as Next, Last, etc.
 		/// </summary>
 		public Func<TagBuilder, TagBuilder, TagBuilder> FunctionToTransformEachPageLink { get; set; }
+		
+		/// <summary>
+        /// Enables or disables the navigation functionality of the ellipses
+        /// </summary>
+        public bool EnableEllipsesNavigation { get; set; }
 
 		/// <summary>
 		/// Enables ASP.NET MVC's unobtrusive AJAX feature. An XHR request will retrieve HTML from the clicked page and replace the innerHtml of the provided element ID.

--- a/src/PagedList.Mvc4.Example/Views/TraditionalPaging/Index.cshtml
+++ b/src/PagedList.Mvc4.Example/Views/TraditionalPaging/Index.cshtml
@@ -47,6 +47,9 @@
 
 <h2>Custom Pager Configurations</h2>
 
+<h3>Functional Ellipses</h3>
+@Html.PagedListPager((IPagedList)ViewBag.Names, page => Url.Action("Index", new { page }), new PagedListRenderOptions() { EnableEllipsesNavigation = true })
+
 <h3>Custom Wording (<em>Spanish Translation Example</em>)</h3>
 @Html.PagedListPager((IPagedList)ViewBag.Names, page => Url.Action("Index", new { page }), new PagedListRenderOptions { LinkToFirstPageFormat = "<< Primera", LinkToPreviousPageFormat = "< Anterior", LinkToNextPageFormat = "Siguiente >", LinkToLastPageFormat = "Última >>" })
 


### PR DESCRIPTION
Added PagedListRenderOptions.EnableEllipsisNavigation with the default
value of "false" for backward compatibility.

Modified the HtmlHelper.Ellipses method to use the new render option.
The pager will use the page before/after the last visible page number as
the link target.

Added an example to the "Custom Pager Configurations" section of the
sample site.
