### PR TITLE
Add select extension

### DIFF
--- a/src/PagedList/PagedList.cs
+++ b/src/PagedList/PagedList.cs
@@ -1,74 +1,101 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
 
 namespace PagedList
 {
-	/// <summary>
-	/// Represents a subset of a collection of objects that can be individually accessed by index and containing metadata about the superset collection of objects this subset was created from.
-	/// </summary>
-	/// <remarks>
-	/// Represents a subset of a collection of objects that can be individually accessed by index and containing metadata about the superset collection of objects this subset was created from.
-	/// </remarks>
-	/// <typeparam name="T">The type of object the collection should contain.</typeparam>
-	/// <seealso cref="IPagedList{T}"/>
-	/// <seealso cref="BasePagedList{T}"/>
-	/// <seealso cref="StaticPagedList{T}"/>
-	/// <seealso cref="List{T}"/>
-	[Serializable]
-	public class PagedList<T> : BasePagedList<T>
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PagedList{T}"/> class that divides the supplied superset into subsets the size of the supplied pageSize. The instance then only containes the objects contained in the subset specified by index.
-		/// </summary>
-		/// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
-		/// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
-		/// <param name="pageSize">The maximum size of any individual subset.</param>
-		/// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
-		/// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
-		public PagedList(IQueryable<T> superset, int pageNumber, int pageSize)
-		{
-			if (pageNumber < 1)
-				throw new ArgumentOutOfRangeException("pageNumber", pageNumber, "PageNumber cannot be below 1.");
-			if (pageSize < 1)
-				throw new ArgumentOutOfRangeException("pageSize", pageSize, "PageSize cannot be less than 1.");
+    /// <summary>
+    /// Represents a subset of a collection of objects that can be individually accessed by index and containing metadata about the superset collection of objects this subset was created from.
+    /// </summary>
+    /// <remarks>
+    /// Represents a subset of a collection of objects that can be individually accessed by index and containing metadata about the superset collection of objects this subset was created from.
+    /// </remarks>
+    /// <typeparam name="T">The type of object the collection should contain.</typeparam>
+    /// <seealso cref="IPagedList{T}"/>
+    /// <seealso cref="BasePagedList{T}"/>
+    /// <seealso cref="StaticPagedList{T}"/>
+    /// <seealso cref="List{T}"/>
+    [Serializable]
+    public class PagedList<T> : BasePagedList<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PagedList{T}"/> class that divides the supplied superset into subsets the size of the supplied pageSize. The instance then only containes the objects contained in the subset specified by index.
+        /// </summary>
+        /// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
+        /// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
+        /// <param name="pageSize">The maximum size of any individual subset.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
+        public PagedList(IQueryable<T> superset, int pageNumber, int pageSize)
+        {
+            if (pageNumber < 1)
+                throw new ArgumentOutOfRangeException("pageNumber", pageNumber, "PageNumber cannot be below 1.");
+            if (pageSize < 1)
+                throw new ArgumentOutOfRangeException("pageSize", pageSize, "PageSize cannot be less than 1.");
 
-			// set source to blank list if superset is null to prevent exceptions
-			TotalItemCount = superset == null ? 0 : superset.Count();
-			PageSize = pageSize;
-			PageNumber = pageNumber;
-			PageCount = TotalItemCount > 0
-						? (int)Math.Ceiling(TotalItemCount / (double)PageSize)
-						: 0;
-			HasPreviousPage = PageNumber > 1;
-			HasNextPage = PageNumber < PageCount;
-			IsFirstPage = PageNumber == 1;
-			IsLastPage = PageNumber >= PageCount;
-			FirstItemOnPage = (PageNumber - 1) * PageSize + 1;
-			var numberOfLastItemOnPage = FirstItemOnPage + PageSize - 1;
-			LastItemOnPage = numberOfLastItemOnPage > TotalItemCount
-							? TotalItemCount
-							: numberOfLastItemOnPage;
+            // set source to blank list if superset is null to prevent exceptions
+            TotalItemCount = superset == null ? 0 : superset.Count();
+            PageSize = pageSize;
+            PageNumber = pageNumber;
+            PageCount = TotalItemCount > 0
+                        ? (int)Math.Ceiling(TotalItemCount / (double)PageSize)
+                        : 0;
+            HasPreviousPage = PageNumber > 1;
+            HasNextPage = PageNumber < PageCount;
+            IsFirstPage = PageNumber == 1;
+            IsLastPage = PageNumber >= PageCount;
+            FirstItemOnPage = (PageNumber - 1) * PageSize + 1;
+            var numberOfLastItemOnPage = FirstItemOnPage + PageSize - 1;
+            LastItemOnPage = numberOfLastItemOnPage > TotalItemCount
+                            ? TotalItemCount
+                            : numberOfLastItemOnPage;
 
-			// add items to internal list
-			if (superset != null && TotalItemCount > 0)
-				Subset.AddRange(pageNumber == 1
-					? superset.Skip(0).Take(pageSize).ToList()
-					: superset.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList()
-				);
-		}
-		
-		/// <summary>
-		/// Initializes a new instance of the <see cref="PagedList{T}"/> class that divides the supplied superset into subsets the size of the supplied pageSize. The instance then only containes the objects contained in the subset specified by index.
-		/// </summary>
-		/// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
-		/// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
-		/// <param name="pageSize">The maximum size of any individual subset.</param>
-		/// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
-		/// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
-		public PagedList(IEnumerable<T> superset, int pageNumber, int pageSize)
-			: this(superset.AsQueryable<T>(), pageNumber, pageSize)
-		{
-		}
-	}
+            // add items to internal list
+            if (superset != null && TotalItemCount > 0)
+                Subset.AddRange(pageNumber == 1
+                    ? superset.Skip(0).Take(pageSize).ToList()
+                    : superset.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList()
+                );
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PagedList{T}"/> class that divides the supplied superset into subsets the size of the supplied pageSize. The instance then only containes the objects contained in the subset specified by index.
+        /// </summary>
+        /// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
+        /// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
+        /// <param name="pageSize">The maximum size of any individual subset.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
+        public PagedList(IEnumerable<T> superset, int pageNumber, int pageSize)
+            : this(superset.AsQueryable<T>(), pageNumber, pageSize)
+        {
+        }
+
+        /// <summary>
+        /// For Clone PagedList
+        /// </summary>
+        /// <param name="pagedListMetaData">Source PagedList</param>
+        /// <param name="superset">Source collection</param>
+        public PagedList(PagedListMetaData pagedListMetaData, IEnumerable<T> superset)
+        {
+
+            // set source to blank list if superset is null to prevent exceptions
+            TotalItemCount = pagedListMetaData.TotalItemCount;
+            PageSize = pagedListMetaData.PageSize;
+            PageNumber = pagedListMetaData.PageNumber;
+            PageCount = pagedListMetaData.PageCount;
+            HasPreviousPage = pagedListMetaData.HasPreviousPage;
+            HasNextPage = pagedListMetaData.HasNextPage;
+            IsFirstPage = pagedListMetaData.IsFirstPage;
+            IsLastPage = pagedListMetaData.IsLastPage;
+            FirstItemOnPage = pagedListMetaData.FirstItemOnPage;
+            LastItemOnPage = pagedListMetaData.LastItemOnPage;
+
+            Subset.AddRange(superset);
+        }
+
+    }
 }

--- a/src/PagedList/PagedList.csproj
+++ b/src/PagedList/PagedList.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <Compile Include="BasePagedList.cs" />
     <Compile Include="IPagedList.cs" />
+    <Compile Include="PagedListForEntityFramework .cs" />
     <Compile Include="PagedList.cs" />
     <Compile Include="PagedListExtensions.cs" />
     <Compile Include="PagedListMetaData.cs" />

--- a/src/PagedList/PagedListExtensions.cs
+++ b/src/PagedList/PagedListExtensions.cs
@@ -70,5 +70,20 @@ namespace PagedList
 					yield return superset.Skip(pageSize * i).Take(pageSize);				
 			}
 		}
+
+        /// <summary>
+        /// Cast to Custom Type
+        /// </summary>
+        /// <param name="source">Source</param>
+        /// <param name="selector">Selector</param>
+        /// <typeparam name="TSource">Input Type</typeparam>
+        /// <typeparam name="TResult">Result Type</typeparam>
+        /// <returns>New PagedList</returns>
+        public static IPagedList<TResult> Select<TSource, TResult>(this PagedList<TSource> source, Func<TSource, TResult> selector)
+        {
+            var subset = ((IEnumerable<TSource>)source).Select(selector);
+            return new PagedList<TResult>(source, subset);
+        }
+
 	}
 }

--- a/src/PagedList/PagedListExtensions.cs
+++ b/src/PagedList/PagedListExtensions.cs
@@ -1,75 +1,78 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace PagedList
 {
-	/// <summary>
-	/// Container for extension methods designed to simplify the creation of instances of <see cref="PagedList{T}"/>.
-	/// </summary>
-	public static class PagedListExtensions
-	{
-		/// <summary>
-		/// Creates a subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.
-		/// </summary>
-		/// <typeparam name="T">The type of object the collection should contain.</typeparam>
-		/// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
-		/// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
-		/// <param name="pageSize">The maximum size of any individual subset.</param>
-		/// <returns>A subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.</returns>
-		/// <seealso cref="PagedList{T}"/>
-		public static IPagedList<T> ToPagedList<T>(this IEnumerable<T> superset, int pageNumber, int pageSize)
-		{
-			return new PagedList<T>(superset, pageNumber, pageSize);
-		}
+    /// <summary>
+    /// Container for extension methods designed to simplify the creation of instances of <see cref="PagedList{T}"/>.
+    /// </summary>
+    public static class PagedListExtensions
+    {
+        /// <summary>
+        /// Creates a subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.
+        /// </summary>
+        /// <typeparam name="T">The type of object the collection should contain.</typeparam>
+        /// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
+        /// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
+        /// <param name="pageSize">The maximum size of any individual subset.</param>
+        /// <returns>A subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.</returns>
+        /// <seealso cref="PagedList{T}"/>
+        public static IPagedList<T> ToPagedList<T>(this IEnumerable<T> superset, int pageNumber, int pageSize)
+        {
+            return new PagedList<T>(superset, pageNumber, pageSize);
+        }
 
-		/// <summary>
-		/// Creates a subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.
-		/// </summary>
-		/// <typeparam name="T">The type of object the collection should contain.</typeparam>
-		/// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
-		/// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
-		/// <param name="pageSize">The maximum size of any individual subset.</param>
-		/// <returns>A subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.</returns>
-		/// <seealso cref="PagedList{T}"/>
-		public static IPagedList<T> ToPagedList<T>(this IQueryable<T> superset, int pageNumber, int pageSize)
-		{
-			return new PagedList<T>(superset, pageNumber, pageSize);
-		}
+        /// <summary>
+        /// Creates a subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.
+        /// </summary>
+        /// <typeparam name="T">The type of object the collection should contain.</typeparam>
+        /// <typeparam name="TKey">Type For Compare</typeparam>
+        /// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
+        /// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
+        /// <param name="pageSize">The maximum size of any individual subset.</param>
+        /// <returns>A subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.</returns>
+        /// <seealso cref="PagedList{T}"/>
+        public static IPagedList<T> ToPagedList<T, TKey>(this IQueryable<T> superset, int pageNumber, int pageSize)
+        {
+            return new PagedList<T>(superset, pageNumber, pageSize);
+        }
 
-		/// <summary>
-		/// Splits a collection of objects into n pages with an (for example, if I have a list of 45 shoes and say 'shoes.Split(5)' I will now have 4 pages of 10 shoes and 1 page of 5 shoes.
-		/// </summary>
-		/// <typeparam name="T">The type of object the collection should contain.</typeparam>
-		/// <param name="superset">The collection of objects to be divided into subsets.</param>
-		/// <param name="numberOfPages">The number of pages this collection should be split into.</param>
-		/// <returns>A subset of this collection of objects, split into n pages.</returns>
-		public static IEnumerable<IEnumerable<T>> Split<T>(this IEnumerable<T> superset, int numberOfPages)
-		{
-			return superset
-				.Select((item, index) => new { index, item })
-				.GroupBy(x => x.index % numberOfPages)
-				.Select(x => x.Select(y => y.item));
-		}
 
-		/// <summary>
-		/// Splits a collection of objects into an unknown number of pages with n items per page (for example, if I have a list of 45 shoes and say 'shoes.Partition(10)' I will now have 4 pages of 10 shoes and 1 page of 5 shoes.
-		/// </summary>
-		/// <typeparam name="T">The type of object the collection should contain.</typeparam>
-		/// <param name="superset">The collection of objects to be divided into subsets.</param>
-		/// <param name="pageSize">The maximum number of items each page may contain.</param>
-		/// <returns>A subset of this collection of objects, split into pages of maximum size n.</returns>
-		public static IEnumerable<IEnumerable<T>> Partition<T>(this IEnumerable<T> superset, int pageSize)
-		{
-			if (superset.Count() < pageSize)
-				yield return superset;
-			else
-			{
-				var numberOfPages = Math.Ceiling(superset.Count() / (double)pageSize);
-				for (var i = 0; i < numberOfPages; i++)
-					yield return superset.Skip(pageSize * i).Take(pageSize);				
-			}
-		}
+        /// <summary>
+        /// Splits a collection of objects into n pages with an (for example, if I have a list of 45 shoes and say 'shoes.Split(5)' I will now have 4 pages of 10 shoes and 1 page of 5 shoes.
+        /// </summary>
+        /// <typeparam name="T">The type of object the collection should contain.</typeparam>
+        /// <param name="superset">The collection of objects to be divided into subsets.</param>
+        /// <param name="numberOfPages">The number of pages this collection should be split into.</param>
+        /// <returns>A subset of this collection of objects, split into n pages.</returns>
+        public static IEnumerable<IEnumerable<T>> Split<T>(this IEnumerable<T> superset, int numberOfPages)
+        {
+            return superset
+                .Select((item, index) => new { index, item })
+                .GroupBy(x => x.index % numberOfPages)
+                .Select(x => x.Select(y => y.item));
+        }
+
+        /// <summary>
+        /// Splits a collection of objects into an unknown number of pages with n items per page (for example, if I have a list of 45 shoes and say 'shoes.Partition(10)' I will now have 4 pages of 10 shoes and 1 page of 5 shoes.
+        /// </summary>
+        /// <typeparam name="T">The type of object the collection should contain.</typeparam>
+        /// <param name="superset">The collection of objects to be divided into subsets.</param>
+        /// <param name="pageSize">The maximum number of items each page may contain.</param>
+        /// <returns>A subset of this collection of objects, split into pages of maximum size n.</returns>
+        public static IEnumerable<IEnumerable<T>> Partition<T>(this IEnumerable<T> superset, int pageSize)
+        {
+            if (superset.Count() < pageSize)
+                yield return superset;
+            else
+            {
+                var numberOfPages = Math.Ceiling(superset.Count() / (double)pageSize);
+                for (var i = 0; i < numberOfPages; i++)
+                    yield return superset.Skip(pageSize * i).Take(pageSize);
+            }
+        }
 
         /// <summary>
         /// Cast to Custom Type
@@ -85,5 +88,21 @@ namespace PagedList
             return new PagedList<TResult>(source, subset);
         }
 
-	}
+        /// <summary>
+        /// Creates a subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.
+        /// </summary>
+        /// <typeparam name="T">The type of object the collection should contain.</typeparam>
+        /// <typeparam name="TKey">Type For Compare</typeparam>
+        /// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
+        /// <param name="keySelector">Expression for Order</param>
+        /// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
+        /// <param name="pageSize">The maximum size of any individual subset.</param>
+        /// <returns>A subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.</returns>
+        /// <seealso cref="PagedListForEntityFramework{T, TKey}"/>
+        public static IPagedList<T> ToPagedListForEntityFramework<T, TKey>(this IQueryable<T> superset, Expression<Func<T, TKey>> keySelector, int pageNumber, int pageSize)
+        {
+            return new PagedListForEntityFramework<T, TKey>(superset, keySelector, pageNumber, pageSize);
+        }
+
+    }
 }

--- a/src/PagedList/PagedListForEntityFramework .cs
+++ b/src/PagedList/PagedListForEntityFramework .cs
@@ -13,32 +13,24 @@ namespace PagedList
     /// Represents a subset of a collection of objects that can be individually accessed by index and containing metadata about the superset collection of objects this subset was created from.
     /// </remarks>
     /// <typeparam name="T">The type of object the collection should contain.</typeparam>
+    /// <typeparam name="TKey"></typeparam>
     /// <seealso cref="IPagedList{T}"/>
     /// <seealso cref="BasePagedList{T}"/>
     /// <seealso cref="StaticPagedList{T}"/>
     /// <seealso cref="List{T}"/>
     [Serializable]
-    public class PagedList<T> : BasePagedList<T>
+    public class PagedListForEntityFramework<T, TKey> : PagedList<T>
     {
-
-
-        /// <summary>
-        /// 
-        /// </summary>
-        protected PagedList()
-        {
-        }
-
-
         /// <summary>
         /// Initializes a new instance of the <see cref="PagedList{T}"/> class that divides the supplied superset into subsets the size of the supplied pageSize. The instance then only containes the objects contained in the subset specified by index.
         /// </summary>
         /// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
+        /// <param name="keySelector">Expression for Order</param>
         /// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
         /// <param name="pageSize">The maximum size of any individual subset.</param>
         /// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
-        public PagedList(IQueryable<T> superset, int pageNumber, int pageSize)
+        public PagedListForEntityFramework(IQueryable<T> superset, Expression<Func<T, TKey>> keySelector, int pageNumber, int pageSize)
         {
             if (pageNumber < 1)
                 throw new ArgumentOutOfRangeException("pageNumber", pageNumber, "PageNumber cannot be below 1.");
@@ -66,61 +58,7 @@ namespace PagedList
             if (superset != null && TotalItemCount > 0)
                 Subset.AddRange(pageNumber == 1
                     ? superset.Take(pageSize).ToList()
-                    : superset.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList()
-                );
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="superset"></param>
-        /// <param name="keySelector"></param>
-        /// <param name="pageNumber"></param>
-        /// <param name="pageSize"></param>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public PagedList(IQueryable<T> superset, Expression<Func<T>> keySelector, int pageNumber, int pageSize)
-        {
-            if (pageNumber < 1)
-                throw new ArgumentOutOfRangeException("pageNumber", pageNumber, "PageNumber cannot be below 1.");
-            if (pageSize < 1)
-                throw new ArgumentOutOfRangeException("pageSize", pageSize, "PageSize cannot be less than 1.");
-
-            // set source to blank list if superset is null to prevent exceptions
-            TotalItemCount = superset == null ? 0 : superset.Count();
-            PageSize = pageSize;
-            PageNumber = pageNumber;
-            PageCount = TotalItemCount > 0
-                        ? (int)Math.Ceiling(TotalItemCount / (double)PageSize)
-                        : 0;
-            HasPreviousPage = PageNumber > 1;
-            HasNextPage = PageNumber < PageCount;
-            IsFirstPage = PageNumber == 1;
-            IsLastPage = PageNumber >= PageCount;
-            FirstItemOnPage = (PageNumber - 1) * PageSize + 1;
-            var numberOfLastItemOnPage = FirstItemOnPage + PageSize - 1;
-            LastItemOnPage = numberOfLastItemOnPage > TotalItemCount
-                            ? TotalItemCount
-                            : numberOfLastItemOnPage;
-
-            // add items to internal list
-            if (superset != null && TotalItemCount > 0)
-                Subset.AddRange(pageNumber == 1 ? superset.Take(pageSize).ToList()
-                    : superset.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList()
-                );
-        }
-
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PagedList{T}"/> class that divides the supplied superset into subsets the size of the supplied pageSize. The instance then only containes the objects contained in the subset specified by index.
-        /// </summary>
-        /// <param name="superset">The collection of objects to be divided into subsets. If the collection implements <see cref="IQueryable{T}"/>, it will be treated as such.</param>
-        /// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance.</param>
-        /// <param name="pageSize">The maximum size of any individual subset.</param>
-        /// <exception cref="ArgumentOutOfRangeException">The specified index cannot be less than zero.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The specified page size cannot be less than one.</exception>
-        public PagedList(IEnumerable<T> superset, int pageNumber, int pageSize)
-            : this(superset.AsQueryable<T>(), pageNumber, pageSize)
-        {
+                    : superset.OrderBy(keySelector).Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList());
         }
 
         /// <summary>
@@ -128,7 +66,7 @@ namespace PagedList
         /// </summary>
         /// <param name="pagedListMetaData">Source PagedList</param>
         /// <param name="superset">Source collection</param>
-        public PagedList(PagedListMetaData pagedListMetaData, IEnumerable<T> superset)
+        public PagedListForEntityFramework(PagedListMetaData pagedListMetaData, IEnumerable<T> superset)
         {
             TotalItemCount = pagedListMetaData.TotalItemCount;
             PageSize = pagedListMetaData.PageSize;


### PR DESCRIPTION
I added the extension Select, as on large samples of their bases often have to be transformed into an DTO types, before selecting the desired page.
So did, you can make the sample directly on the Collections of context EF, using ToPagedListForEntityFramework.

I tried not to break compatibility ...



