### PR TITLE
Allow to get last page rather than first

### DIFF
--- a/src/PagedList/PagedList.cs
+++ b/src/PagedList/PagedList.cs
@@ -36,10 +36,10 @@ namespace PagedList
 			// set source to blank list if superset is null to prevent exceptions
 			TotalItemCount = superset == null ? 0 : superset.Count();
 			PageSize = pageSize;
-			PageNumber = pageNumber;
 			PageCount = TotalItemCount > 0
 						? (int)Math.Ceiling(TotalItemCount / (double)PageSize)
 						: 0;
+			PageNumber = (pageNumber == int.MaxValue) ? PageCount : pageNumber;
 			HasPreviousPage = PageNumber > 1;
 			HasNextPage = PageNumber < PageCount;
 			IsFirstPage = PageNumber == 1;


### PR DESCRIPTION
[Refers to this issue](https://github.com/troygoode/PagedList/issues/115). By passing in `int.MaxValue`, will get the last page rather than the first. So you can have it both ways.